### PR TITLE
Update upstream/CVE-2020-8563.json

### DIFF
--- a/upstream/CVE-2020-8563.json
+++ b/upstream/CVE-2020-8563.json
@@ -1,0 +1,44 @@
+{
+  "id": "CVE-2020-8563",
+  "modified": "2020-10-15T22:00:44Z",
+  "published": "2020-10-15T22:00:44Z",
+  "summary": "Secret leaks in kube-controller-manager when using vSphere provider",
+  "details": "In Kubernetes clusters using VSphere as a cloud provider, with a logging level set to 4 or above, VSphere cloud credentials will be leaked in the cloud controller manager's log. This affects \u003c v1.19.3.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "k8s.io/controller-manager"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "1.19.0"
+            },
+            {
+              "fixed": "1.19.3"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/95621"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2020-8563"
+    }
+  ]
+}


### PR DESCRIPTION
This PR updates upstream/CVE-2020-8563.json