### PR TITLE
Update upstream/CVE-2022-3294.json

### DIFF
--- a/upstream/CVE-2022-3294.json
+++ b/upstream/CVE-2022-3294.json
@@ -1,0 +1,62 @@
+{
+  "id": "CVE-2022-3294",
+  "modified": "2022-11-08T21:33:26Z",
+  "published": "2022-11-08T21:33:26Z",
+  "summary": "Node address isn't always verified when proxying",
+  "details": "Users may have access to secure endpoints in the control plane network. Kubernetes clusters are only affected if an untrusted user can modify Node objects and send proxy requests to them. Kubernetes supports node proxying, which allows clients of kube-apiserver to access endpoints of a Kubelet to establish connections to Pods, retrieve container logs, and more. While Kubernetes already validates the proxying address for Nodes, a bug in kube-apiserver made it possible to bypass this validation. Bypassing this validation could allow authenticated requests destined for Nodes to to the API server's private network.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "kubernetes",
+        "name": "k8s.io/apiserver"
+      },
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H"
+        }
+      ],
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "1.25.0"
+            },
+            {
+              "last_affected": "1.25.3"
+            },
+            {
+              "introduced": "1.24.0"
+            },
+            {
+              "last_affected": "1.24.7"
+            },
+            {
+              "introduced": "1.23.0"
+            },
+            {
+              "last_affected": "1.23.13"
+            },
+            {
+              "introduced": "1.22.0"
+            },
+            {
+              "last_affected": "1.22.15"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/kubernetes/kubernetes/issues/113757"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/cverecord?id=CVE-2022-3294"
+    }
+  ]
+}


### PR DESCRIPTION
This PR updates upstream/CVE-2022-3294.json